### PR TITLE
Set example version v8.6.2

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -38,9 +38,9 @@ provider "docker" {
 # -----------------------------------------------------------------------------
 
 locals {
-  elasticsearch_version = "8.7.0"
-  logstash_version      = "8.7.0"
-  kibana_version        = "8.7.0"
+  elasticsearch_version = "8.6.2"
+  logstash_version      = "8.6.2"
+  kibana_version        = "8.6.2"
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Version v8.7.0 showed inconsistent and I had to rollback and use one previous version.

- Logstash was failing during deploy.